### PR TITLE
Bump dependency versions

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -4,30 +4,30 @@
     <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
   </PropertyGroup>
   <ItemGroup>
-    <PackageVersion Include="DeterministicIoPackaging" Version="0.26.0" />
+    <PackageVersion Include="DeterministicIoPackaging" Version="0.27.0" />
     <PackageVersion Include="MarkdownSnippets.MsBuild" Version="28.2.0" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
     <PackageVersion Include="NUnit" Version="4.6.1" />
     <PackageVersion Include="NUnit3TestAdapter" Version="6.2.0" />
     <PackageVersion Include="ProjectDefaults" Version="1.0.174" />
-    <PackageVersion Include="Syncfusion.DocIO.Net.Core" Version="33.2.7" />
-    <PackageVersion Include="Syncfusion.DocIORenderer.Net.Core" Version="33.2.7" />
-    <PackageVersion Include="Syncfusion.EJ2.PdfViewer.AspNet.Core" Version="33.2.7" />
-    <PackageVersion Include="Syncfusion.Pdf.Net.Core" Version="33.2.7" />
-    <PackageVersion Include="Syncfusion.Presentation.Net.Core" Version="33.2.7" />
-    <PackageVersion Include="Syncfusion.PresentationRenderer.Net.Core" Version="33.2.7" />
-    <PackageVersion Include="Syncfusion.XlsIO.Net.Core" Version="33.2.7" />
-    <PackageVersion Include="Syncfusion.XlsIORenderer.Net.Core" Version="33.2.7" />
-    <PackageVersion Include="Verify" Version="31.17.0" />
+    <PackageVersion Include="Syncfusion.DocIO.Net.Core" Version="33.2.8" />
+    <PackageVersion Include="Syncfusion.DocIORenderer.Net.Core" Version="33.2.8" />
+    <PackageVersion Include="Syncfusion.EJ2.PdfViewer.AspNet.Core" Version="33.2.8" />
+    <PackageVersion Include="Syncfusion.Pdf.Net.Core" Version="33.2.8" />
+    <PackageVersion Include="Syncfusion.Presentation.Net.Core" Version="33.2.8" />
+    <PackageVersion Include="Syncfusion.PresentationRenderer.Net.Core" Version="33.2.8" />
+    <PackageVersion Include="Syncfusion.XlsIO.Net.Core" Version="33.2.8" />
+    <PackageVersion Include="Syncfusion.XlsIORenderer.Net.Core" Version="33.2.8" />
+    <PackageVersion Include="Verify" Version="31.18.0" />
     <PackageVersion Include="Verify.DiffPlex" Version="3.1.2" />
-    <PackageVersion Include="Verify.NUnit" Version="31.17.0" />
+    <PackageVersion Include="Verify.NUnit" Version="31.18.0" />
     <PackageVersion Include="Microsoft.Sbom.Targets" Version="4.1.5" />
     <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="10.0.8" />
     <PackageVersion Include="Argon" Version="0.34.0" />
     <PackageVersion Include="DiffEngine" Version="19.2.0" />
     <PackageVersion Include="EmptyFiles" Version="8.18.1" />
     <PackageVersion Include="SimpleInfoName" Version="3.2.0" />
-    <PackageVersion Include="SponsorCheck" Version="0.4.0" GitHubSponsorsAccount="VerifyTests" />
+    <PackageVersion Include="SponsorCheck" Version="0.5.0" GitHubSponsorsAccount="VerifyTests" />
     <!-- CVE -->
     <PackageVersion Include="System.Text.Json" Version="10.0.8" />
   </ItemGroup>


### PR DESCRIPTION
Update central package versions in Directory.Packages.props. Notable bumps: DeterministicIoPackaging 0.26.0→0.27.0, Microsoft.NET.Test.Sdk 18.5.1→18.6.0, Syncfusion packages 33.2.7→33.2.8, Verify & Verify.NUnit 31.17.0→31.18.0, and SponsorCheck 0.4.0→0.5.0. Routine dependency updates to pick up fixes and improvements.