### PR TITLE
Add a deterministic pdf target

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -2,7 +2,7 @@
 <Project>
   <PropertyGroup>
     <NoWarn>CS1591;CS0649;NU1608;NU1109</NoWarn>
-    <Version>3.0.0</Version>
+    <Version>3.1.0</Version>
     <AssemblyVersion>1.0.0</AssemblyVersion>
     <LangVersion>preview</LangVersion>
     <PackageTags>Syncfusion, Verify</PackageTags>

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -4,6 +4,7 @@
     <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
   </PropertyGroup>
   <ItemGroup>
+    <PackageVersion Include="DeterministicPdf" Version="1.0.1" />
     <PackageVersion Include="DeterministicIoPackaging" Version="0.30.0" />
     <PackageVersion Include="MarkdownSnippets.MsBuild" Version="28.4.1" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />

--- a/src/Verify.Syncfusion/Verify.Syncfusion.csproj
+++ b/src/Verify.Syncfusion/Verify.Syncfusion.csproj
@@ -7,6 +7,7 @@
   <ItemGroup>
     <None Include="..\..\OsmfEula.txt" Pack="true" PackagePath="\" />
     <PackageReference Include="DeterministicIoPackaging" />
+    <PackageReference Include="DeterministicPdf" />
     <PackageReference Include="Verify" />
     <PackageReference Include="Syncfusion.DocIORenderer.Net.Core" />
     <PackageReference Include="Syncfusion.Pdf.Net.Core" />

--- a/src/Verify.Syncfusion/VerifySyncfusion_Pdf.cs
+++ b/src/Verify.Syncfusion/VerifySyncfusion_Pdf.cs
@@ -1,4 +1,6 @@
-﻿namespace VerifyTests;
+﻿using DeterministicPdf;
+
+namespace VerifyTests;
 
 public static partial class VerifySyncfusion
 {
@@ -68,6 +70,19 @@ public static partial class VerifySyncfusion
         var pdfStream = new MemoryStream();
         document.Save(pdfStream);
         pdfStream.Position = 0;
+
+        // The document is already saved here to feed the renderer, so the pdf snapshot costs only the
+        // neutralizing pass. It is always the full document, regardless of PagesToInclude, which
+        // trims the rendered pages below. Mirrors the xlsx/docx/pptx targets in the sibling formats.
+        if (!settings.IsTargetExcluded("pdf"))
+        {
+            yield return new("pdf", PdfNormalizer.Normalize(pdfStream), name, performConversion: false)
+            {
+                BypassComparersForSubsequentOnDifference = true
+            };
+            pdfStream.Position = 0;
+        }
+
         var pngDevice = settings.GetPdfPngDevice(document);
         pngDevice.Load(pdfStream);
         for (var index = 0; index < pagesToInclude; index++)


### PR DESCRIPTION
The Excel, Word and PowerPoint paths emit the source document as a target, made deterministic via DeterministicPackage. The pdf path emitted only text and the rendered pages. It now emits the document too, neutralized with DeterministicPdf.

The document is already saved to a stream to feed the renderer, so the target costs only the neutralizing pass.

Not verified locally: the test suite requires the SyncfusionLicense environment variable.